### PR TITLE
fix(auth): restore phone OTP for new and re-created accounts

### DIFF
--- a/lib/chatbot-api/functions/phone-otp-auth/define-auth-challenge.js
+++ b/lib/chatbot-api/functions/phone-otp-auth/define-auth-challenge.js
@@ -16,8 +16,21 @@ exports.handler = async (event) => {
     
     const { session, triggerSource } = event.request;
     const userName = event.userName;
-    
+
     try {
+        // The app client has PreventUserExistenceErrors ENABLED, so Cognito
+        // never throws UserNotFoundException for CUSTOM_AUTH. It invokes the
+        // triggers anyway with request.userNotFound = true and no user
+        // attributes; without this guard the flow continues into a challenge
+        // that can never send an SMS. Failing here returns
+        // NotAuthorizedException to the client, which falls back to sign-up.
+        if (event.request.userNotFound) {
+            console.log(`User not found: ${userName}. Failing authentication.`);
+            event.response.issueTokens = false;
+            event.response.failAuthentication = true;
+            return event;
+        }
+
         // If no session exists or empty session, this is the first challenge
         if (!session || session.length === 0) {
             console.log(`First authentication attempt for user: ${userName}`);

--- a/lib/user-interface/app/src/components/CustomLogin.tsx
+++ b/lib/user-interface/app/src/components/CustomLogin.tsx
@@ -193,21 +193,30 @@ const CustomLogin: React.FC<CustomLoginProps> = ({ showLogo = true, showLanguage
         
         // Handle the authentication response for existing users
         if (cognitoUser.challengeName === 'CUSTOM_CHALLENGE') {
-          setCognitoUserForSms(cognitoUser);
-          setSmsCodeSent(true);
-          setIsNewUserConfirmation(false);
-          setSuccessMessage('auth.smsCodeSent');
-          // console.log('SMS code sent for existing user');
-              } else {
-                // console.log('User authenticated successfully');
-                login(cognitoUser);
-                handleSuccessfulAuthentication();
-              }
-        
+          if (cognitoUser.challengeParam?.error) {
+            // The SMS lambda reports send failures through this challenge
+            // parameter; without this check the UI claims a code was sent
+            setError('auth.errorSendingCode');
+          } else {
+            setCognitoUserForSms(cognitoUser);
+            setSmsCodeSent(true);
+            setIsNewUserConfirmation(false);
+            setSuccessMessage('auth.smsCodeSent');
+          }
+        } else {
+          // console.log('User authenticated successfully');
+          login(cognitoUser);
+          handleSuccessfulAuthentication();
+        }
+
       } catch (signInError: any) {
         // console.log('SignIn error:', signInError.code);
-        
-        if (signInError.code === 'UserNotFoundException') {
+
+        // NotAuthorizedException is how "user does not exist" surfaces here:
+        // the app client prevents user existence errors, so the define-auth
+        // lambda fails auth for unknown numbers instead of Cognito throwing
+        // UserNotFoundException. Treat both as "create the account".
+        if (signInError.code === 'UserNotFoundException' || signInError.code === 'NotAuthorizedException') {
           // User doesn't exist, create them first
           // console.log('Creating new user for phone:', formattedPhone);
           
@@ -241,12 +250,16 @@ const CustomLogin: React.FC<CustomLoginProps> = ({ showLogo = true, showLanguage
             if (signUpError.code === 'UsernameExistsException') {
               // User was created between our attempts, try signin again
               cognitoUser = await signInWithPhone(formattedPhone);
-              
+
               if (cognitoUser.challengeName === 'CUSTOM_CHALLENGE') {
-                setCognitoUserForSms(cognitoUser);
-                setSmsCodeSent(true);
-                setIsNewUserConfirmation(false);
-                setSuccessMessage('auth.smsCodeSent');
+                if (cognitoUser.challengeParam?.error) {
+                  setError('auth.errorSendingCode');
+                } else {
+                  setCognitoUserForSms(cognitoUser);
+                  setSmsCodeSent(true);
+                  setIsNewUserConfirmation(false);
+                  setSuccessMessage('auth.smsCodeSent');
+                }
               } else {
                 login(cognitoUser);
                 handleSuccessfulAuthentication();
@@ -333,7 +346,7 @@ const CustomLogin: React.FC<CustomLoginProps> = ({ showLogo = true, showLanguage
         try {
           const cognitoUser = await signInWithPhone(pendingPhoneNumber);
 
-          if (cognitoUser.challengeName === 'CUSTOM_CHALLENGE') {
+          if (cognitoUser.challengeName === 'CUSTOM_CHALLENGE' && !cognitoUser.challengeParam?.error) {
             // Switch to custom auth mode
             setCognitoUserForSms(cognitoUser);
             setIsNewUserConfirmation(false);
@@ -491,7 +504,7 @@ const CustomLogin: React.FC<CustomLoginProps> = ({ showLogo = true, showLanguage
           
           const result = await signInWithPhone(phoneNumber);
 
-          if (result.challengeName === 'CUSTOM_CHALLENGE') {
+          if (result.challengeName === 'CUSTOM_CHALLENGE' && !result.challengeParam?.error) {
             setCognitoUserForSms(result);
             setSuccessMessage('auth.smsCodeResent');
             setSmsCode(''); // Clear previous code

--- a/lib/user-interface/app/src/translations/ar.json
+++ b/lib/user-interface/app/src/translations/ar.json
@@ -204,6 +204,7 @@
     "auth.errorSignUp": "حدث خطأ أثناء إنشاء الحساب",
     "auth.errorVerification": "خطأ في التحقق من حسابك",
     "auth.errorResendCode": "خطأ في إعادة إرسال رمز التحقق",
+    "auth.errorSendingCode": "تعذّر إرسال رمز التحقق. يرجى التحقق من رقم الهاتف والمحاولة مرة أخرى.",
     "auth.errorRequestPasswordReset": "خطأ في طلب إعادة تعيين كلمة المرور",
     "auth.errorResetPassword": "خطأ في إعادة تعيين كلمة المرور",
     "auth.errorPasswordChange": "خطأ في تغيير كلمة المرور",

--- a/lib/user-interface/app/src/translations/en.json
+++ b/lib/user-interface/app/src/translations/en.json
@@ -207,6 +207,7 @@
     "auth.errorSignUp": "An error occurred during sign up",
     "auth.errorVerification": "Error verifying your account",
     "auth.errorResendCode": "Error resending verification code",
+    "auth.errorSendingCode": "We couldn't send the verification code. Please check the phone number and try again.",
     "auth.errorRequestPasswordReset": "Error requesting password reset",
     "auth.errorResetPassword": "Error resetting password",
     "auth.errorPasswordChange": "Error changing password",

--- a/lib/user-interface/app/src/translations/es.json
+++ b/lib/user-interface/app/src/translations/es.json
@@ -201,6 +201,7 @@
     "auth.errorSignUp": "Ha ocurrido un error durante el registro",
     "auth.errorVerification": "Error al verificar su cuenta",
     "auth.errorResendCode": "Error al reenviar el código de verificación",
+    "auth.errorSendingCode": "No se pudo enviar el código de verificación. Por favor, verifique el número de teléfono e intente de nuevo.",
     "auth.errorRequestPasswordReset": "Error al solicitar restablecimiento de contraseña",
     "auth.errorResetPassword": "Error al restablecer la contraseña",
     "auth.errorPasswordChange": "Error al cambiar la contraseña",

--- a/lib/user-interface/app/src/translations/vi.json
+++ b/lib/user-interface/app/src/translations/vi.json
@@ -206,6 +206,7 @@
     "auth.errorSignUp": "Đã xảy ra lỗi trong quá trình đăng ký",
     "auth.errorVerification": "Lỗi xác minh tài khoản của bạn",
     "auth.errorResendCode": "Lỗi khi gửi lại mã xác nhận",
+    "auth.errorSendingCode": "Không thể gửi mã xác minh. Vui lòng kiểm tra số điện thoại và thử lại.",
     "auth.errorRequestPasswordReset": "Lỗi khi yêu cầu đặt lại mật khẩu",
     "auth.errorResetPassword": "Lỗi khi đặt lại mật khẩu",
     "auth.errorPasswordChange": "Lỗi khi thay đổi mật khẩu",

--- a/lib/user-interface/app/src/translations/zh.json
+++ b/lib/user-interface/app/src/translations/zh.json
@@ -201,6 +201,7 @@
     "auth.errorSignUp": "注册过程中发生错误",
     "auth.errorVerification": "验证账号时出错",
     "auth.errorResendCode": "重新发送验证码时出错",
+    "auth.errorSendingCode": "验证码发送失败。请检查手机号码后重试。",
     "auth.errorRequestPasswordReset": "请求重置密码时出错",
     "auth.errorResetPassword": "重置密码时出错",
     "auth.errorPasswordChange": "更改密码时出错",


### PR DESCRIPTION
## Problem

Phone OTP login worked for existing accounts, but any phone number **without** an existing Cognito user (a brand-new signup, or logging back in after deleting your account) never received an SMS. The UI showed "SMS code sent" and waited forever. Confirmed live in both staging and prod.

## Root cause

The user pool app client has `PreventUserExistenceErrors: ENABLED`, so `Auth.signIn(phone)` for an unknown number never throws `UserNotFoundException` in the CUSTOM_AUTH flow. Cognito instead invokes the auth triggers with `request.userNotFound = true` and empty user attributes:

- `define-auth-challenge` ignored the flag and issued a `CUSTOM_CHALLENGE` for the ghost user
- `create-auth-challenge` had no phone number to text, caught its own error, and returned a challenge whose only content was `publicChallengeParameters.error`
- the frontend treated any `CUSTOM_CHALLENGE` as "code sent" and never read `challengeParam.error`, so the failure was invisible and the sign-up fallback (`catch UserNotFoundException -> Auth.signUp`) was unreachable dead code

CloudWatch evidence (staging): `DefineAuthChallenge` events with `"userNotFound": true` followed by `CreateAuthChallenge` logging `Phone number not found in user attributes`, with zero completed phone signups in 30+ days.

## Fix

- **define-auth-challenge.js**: fail authentication immediately when `event.request.userNotFound` is set. The client now receives `NotAuthorizedException` instead of a dead-end challenge. `PreventUserExistenceErrors` stays ENABLED (still protects the email/password flow from account enumeration).
- **CustomLogin.tsx**: the phone flow treats `NotAuthorizedException` like `UserNotFoundException` and falls back to sign-up (the existing `UsernameExistsException` fallback still covers accounts that do exist). All four places that accept a `CUSTOM_CHALLENGE` (initial send, signup race fallback, post-confirmation, resend) now check `challengeParam.error` first and show a real error instead of "code sent".
- **translations**: new `auth.errorSendingCode` string in en/es/zh/ar/vi.

## Verification

- Unit-tested the trigger: `userNotFound` fails auth; normal challenge flow, language handshake, token issuance, and the 3-attempt lockout are unchanged. `tsc --noEmit` clean.
- Deployed to staging (run 30098016974) and verified live: `initiate-auth --auth-flow CUSTOM_AUTH` for a nonexistent number now returns `NotAuthorizedException` (previously a dead challenge with an `error` param), and the served bundle contains the new handling.
- Manually confirmed on staging: delete account, sign in again with the same number, verification SMS and login OTP both arrive, login completes.

## Notes

- Cherry-pick of 8c85585 from `staging`; other staging-only work (S3 version expiry, large-document processing, CI caching, TTS) is intentionally **not** included.
- Merging this PR auto-deploys prod via `deploy.yml` (push to `main`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved phone authentication handling when verification codes cannot be sent.
  * Prevented users from entering SMS verification when the phone number is invalid or unavailable.
  * Added clearer error handling for failed code resends and authentication attempts.

* **Translations**
  * Added localized verification-code error messages in English, Arabic, Spanish, Vietnamese, and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->