### PR TITLE
release: bring staging fixes to prod (everything except TTS)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,10 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '20'  # Use Node.js version 20.x, which is compatible with "@types/node": "20.12.7"
+        cache: 'npm'
+        cache-dependency-path: |
+          package-lock.json
+          lib/user-interface/app/package-lock.json
 
     # Step 3: Install backend dependencies (from the root folder)
     - name: Install backend dependencies
@@ -44,6 +48,17 @@ jobs:
     # Step 6: Bootstrap the AWS environment (from the root folder)
     - name: Bootstrap AWS environment
       run: npx cdk bootstrap
+
+    # Cache CDK bundled Lambda assets. Assets use assetHashType SOURCE, so cdk
+    # skips Docker bundling for any asset already staged in a restored cdk.out;
+    # only assets whose source actually changed are re-bundled.
+    - name: Cache CDK bundled assets
+      uses: actions/cache@v4
+      with:
+        path: cdk.out
+        key: cdk-out-${{ hashFiles('lib/chatbot-api/functions/**') }}
+        restore-keys: |
+          cdk-out-
 
     # Step 7: Deploy the CDK stack (from the root folder)
     - name: Deploy CDK stack

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -22,6 +22,10 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '20'  # Use Node.js version 20.x, which is compatible with "@types/node": "20.12.7"
+        cache: 'npm'
+        cache-dependency-path: |
+          package-lock.json
+          lib/user-interface/app/package-lock.json
 
     # Step 3: Install backend dependencies (from the root folder)
     - name: Install backend dependencies
@@ -44,6 +48,17 @@ jobs:
     # Step 6: Bootstrap the AWS environment (from the root folder)
     - name: Bootstrap AWS environment
       run: npx cdk bootstrap
+
+    # Cache CDK bundled Lambda assets. Assets use assetHashType SOURCE, so cdk
+    # skips Docker bundling for any asset already staged in a restored cdk.out;
+    # only assets whose source actually changed are re-bundled.
+    - name: Cache CDK bundled assets
+      uses: actions/cache@v4
+      with:
+        path: cdk.out
+        key: cdk-out-${{ hashFiles('lib/chatbot-api/functions/**') }}
+        restore-keys: |
+          cdk-out-
 
     # Step 7: Deploy the CDK stack (from the root folder)
     - name: Deploy CDK stack

--- a/lib/chatbot-api/buckets/buckets.ts
+++ b/lib/chatbot-api/buckets/buckets.ts
@@ -32,9 +32,24 @@ export class S3BucketStack extends cdk.Stack {
       encryptionKey: props?.encryptionKey,
       cors: [{
         allowedMethods: [s3.HttpMethods.GET,s3.HttpMethods.POST,s3.HttpMethods.PUT,s3.HttpMethods.DELETE],
-        allowedOrigins: ['*'],      
+        allowedOrigins: ['*'],
         allowedHeaders: ["*"]
-      }]
+      }],
+      lifecycleRules: [
+        {
+          // Retention: the bucket is versioned, so deletes (original PDFs,
+          // raw OCR) only add delete markers — the data survives as
+          // noncurrent versions. Expire those quickly so deleted sensitive
+          // documents are actually gone.
+          id: 'ExpireNoncurrentVersions',
+          noncurrentVersionExpiration: cdk.Duration.days(1),
+        },
+        {
+          // Clean up delete markers whose versions have all expired
+          id: 'CleanupExpiredDeleteMarkers',
+          expiredObjectDeleteMarker: true,
+        }
+      ]
     });
 
     // Apply restrictive bucket policy to the knowledge bucket (which contains IEP documents)

--- a/lib/chatbot-api/buckets/buckets.ts
+++ b/lib/chatbot-api/buckets/buckets.ts
@@ -5,6 +5,7 @@ import { createBucketPolicy } from './bucket-policy';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as kms from 'aws-cdk-lib/aws-kms';
 import { getEnvironment } from '../../tags';
+import { createIepDataDenyStatement } from '../security';
 
 export interface S3BucketStackProps extends cdk.StackProps {
   encryptionKey?: kms.IKey;
@@ -50,16 +51,14 @@ export class S3BucketStack extends cdk.Stack {
       allowedUsers: allowedUsers
     });
     
-    // Add direct permissions for Lambda functions in the same stack
+    // Add direct permissions for the project owner. Lambda functions access
+    // the bucket through their execution roles (granted in functions.ts);
+    // no service-principal allows are needed.
     this.knowledgeBucket.addToResourcePolicy(new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,
       principals: [
         new iam.ArnPrincipal(`arn:aws:iam::${accountId}:user/dhruv`),
-        new iam.ArnPrincipal(`arn:aws:iam::${accountId}:root`),
-        // Allow Lambda service principal (specific roles will be granted by CDK automatically)
-        new iam.ServicePrincipal('lambda.amazonaws.com'),
-        // Allow API Gateway service principal for the uploads via frontend
-        new iam.ServicePrincipal('apigateway.amazonaws.com')
+        new iam.ArnPrincipal(`arn:aws:iam::${accountId}:root`)
       ],
       actions: [
         's3:GetObject',
@@ -73,7 +72,20 @@ export class S3BucketStack extends cdk.Stack {
         `${this.knowledgeBucket.bucketArn}/*`
       ]
     }));
-    
+
+    // This account is shared with other projects/users: explicitly deny any
+    // principal outside the IEP-data allowlist, regardless of their IAM
+    // identity policies. AWS service principals stay exempt.
+    this.knowledgeBucket.addToResourcePolicy(createIepDataDenyStatement(
+      accountId,
+      ['s3:*'],
+      [
+        this.knowledgeBucket.bucketArn,
+        `${this.knowledgeBucket.bucketArn}/*`
+      ]
+    ));
+
+
     // Add back the deny statement for non-HTTPS requests
     this.knowledgeBucket.addToResourcePolicy(new iam.PolicyStatement({
       effect: iam.Effect.DENY,

--- a/lib/chatbot-api/functions/functions.ts
+++ b/lib/chatbot-api/functions/functions.ts
@@ -178,6 +178,9 @@ export class LambdaFunctionStack extends cdk.Stack {
     this.ddbServiceFunction = createTaggedLambda('DDBServiceFunction', {
       runtime: lambda.Runtime.PYTHON_3_12,
       code: lambda.Code.fromAsset(path.join(__dirname, 'metadata-handler/ddb-service'), {
+        // SOURCE hashing lets CDK skip Docker bundling when the staged asset
+        // already exists in cdk.out (restored from the CI cache)
+        assetHashType: cdk.AssetHashType.SOURCE,
         bundling: {
           image: lambda.Runtime.PYTHON_3_12.bundlingImage,
           command: [
@@ -284,6 +287,7 @@ export class LambdaFunctionStack extends cdk.Stack {
       const func = createTaggedLambda(name, {
         runtime: lambda.Runtime.PYTHON_3_12,
         code: lambda.Code.fromAsset(path.join(__dirname, handlerPath), {
+          assetHashType: cdk.AssetHashType.SOURCE,
           bundling: {
             image: lambda.Runtime.PYTHON_3_12.bundlingImage,
             command: [
@@ -440,6 +444,7 @@ export class LambdaFunctionStack extends cdk.Stack {
     this.orchestratorFunction = createTaggedLambda('OrchestratorFunction', {
       runtime: lambda.Runtime.PYTHON_3_12,
       code: lambda.Code.fromAsset(path.join(__dirname, 'metadata-handler'), {
+        assetHashType: cdk.AssetHashType.SOURCE,
         bundling: {
           image: lambda.Runtime.PYTHON_3_12.bundlingImage,
           command: [
@@ -618,6 +623,7 @@ export class LambdaFunctionStack extends cdk.Stack {
     const pdfGeneratorFunction = createTaggedLambda('PDFGeneratorFunction', {
       runtime: lambda.Runtime.NODEJS_20_X,
       code: lambda.Code.fromAsset(path.join(__dirname, 'pdf-generator'), {
+        assetHashType: cdk.AssetHashType.SOURCE,
         bundling: {
           image: lambda.Runtime.NODEJS_20_X.bundlingImage,
           command: [

--- a/lib/chatbot-api/functions/functions.ts
+++ b/lib/chatbot-api/functions/functions.ts
@@ -373,6 +373,7 @@ export class LambdaFunctionStack extends cdk.Stack {
     const functionsNeedingDDBAccess = [
       this.mistralOCRFunction,
       this.redactOCRFunction,
+      this.deleteOriginalFunction,
       this.parsingAgentFunction,
       this.extractMeetingNotesFunction,
       this.translateContentFunction,

--- a/lib/chatbot-api/functions/metadata-handler/ddb-service/handler.py
+++ b/lib/chatbot-api/functions/metadata-handler/ddb-service/handler.py
@@ -9,10 +9,12 @@ import traceback
 from datetime import datetime
 from decimal import Decimal
 from s3_content_handler import (
-    save_content_to_s3, 
-    get_content_from_s3, 
+    save_content_to_s3,
+    get_content_from_s3,
     delete_content_from_s3,
-    migrate_dynamodb_to_s3
+    migrate_dynamodb_to_s3,
+    save_ocr_to_s3,
+    get_ocr_s3_key
 )
 
 # Initialize DynamoDB client
@@ -85,6 +87,8 @@ def lambda_handler(event, context):
             return save_ocr_data(params)
         elif operation == 'get_ocr_data':
             return get_ocr_data(params)
+        elif operation == 'delete_ocr_data':
+            return delete_ocr_data(params)
         elif operation == 'get_analysis_data':
             return get_analysis_data(params)
         elif operation == 'save_final_results':
@@ -225,6 +229,33 @@ def save_results(params):
         }, default=str)
     }
 
+def _cleanup_unredacted_artifacts(iep_id, child_id):
+    """Delete the original uploaded document and raw OCR for a document.
+
+    Data-retention policy: only redacted content may persist. On the happy
+    path the DeleteOriginal step handles this; this runs on failure so a
+    FAILED document also retains no unredacted artifacts.
+    """
+    response = table.get_item(Key={'iepId': iep_id, 'childId': child_id})
+    item = response.get('Item', {})
+
+    # Original uploaded file (documentUrl = s3://bucket/key)
+    document_url = item.get('documentUrl') or ''
+    if document_url.startswith('s3://'):
+        bucket, _, key = document_url[len('s3://'):].partition('/')
+        if bucket and key:
+            delete_content_from_s3(key, bucket)
+
+    # Raw OCR: S3 payload (new format) and/or inline attribute (legacy)
+    s3_ref = item.get('ocr_result_s3_ref')
+    if s3_ref:
+        delete_content_from_s3(s3_ref['s3Key'], s3_ref['bucket'])
+    table.update_item(
+        Key={'iepId': iep_id, 'childId': child_id},
+        UpdateExpression="REMOVE ocr_result, ocr_result_s3_ref"
+    )
+
+
 def record_failure(params):
     """Record processing failure"""
     iep_id = params['iep_id']
@@ -232,7 +263,13 @@ def record_failure(params):
     user_id = params['user_id']
     error_message = params['error_message']
     failed_step = params.get('failed_step', 'unknown')
-    
+
+    # Best-effort purge of unredacted artifacts; must never mask the failure record
+    try:
+        _cleanup_unredacted_artifacts(iep_id, child_id)
+    except Exception as cleanup_error:
+        print(f"Cleanup of unredacted artifacts after failure did not complete: {str(cleanup_error)}")
+
     table.update_item(
         Key={
             'iepId': iep_id,
@@ -285,69 +322,140 @@ def get_document(params):
         'body': json.dumps(item, default=str)
     }
 
+# Only these OCR attribute names may appear in update expressions
+OCR_DATA_TYPES = {'ocr_result', 'redacted_ocr_result'}
+
+
+def _validate_ocr_data_type(data_type):
+    if data_type not in OCR_DATA_TYPES:
+        raise ValueError(f"Invalid OCR data_type: {data_type}")
+
+
 def save_ocr_data(params):
-    """Save OCR data to DynamoDB"""
+    """Save OCR data to S3 with a reference on the DynamoDB item.
+
+    OCR payloads for large documents exceed the DynamoDB 400KB item limit
+    (raw + redacted copies together broke processing), so the payload goes to
+    S3 and the item only carries {data_type}_s3_ref. Any legacy inline
+    attribute is removed in the same update.
+    """
     iep_id = params['iep_id']
     child_id = params['child_id']
     user_id = params['user_id']
     ocr_data = params['ocr_data']
     data_type = params.get('data_type', 'ocr_result')  # 'ocr_result' or 'redacted_ocr_result'
-    
-    update_expression = f"SET {data_type} = :ocr_data, updated_at = :updated_at"
-    expression_values = {
-        ':ocr_data': ocr_data,
-        ':updated_at': datetime.utcnow().isoformat()
-    }
-    
+    _validate_ocr_data_type(data_type)
+
+    s3_ref = save_ocr_to_s3(iep_id, child_id, data_type, ocr_data)
+
     table.update_item(
         Key={
             'iepId': iep_id,
             'childId': child_id
         },
-        UpdateExpression=update_expression,
-        ExpressionAttributeValues=expression_values
+        UpdateExpression=f"SET {data_type}_s3_ref = :s3_ref, updated_at = :updated_at REMOVE {data_type}",
+        ExpressionAttributeValues={
+            ':s3_ref': {'bucket': s3_ref['bucket'], 's3Key': s3_ref['s3Key']},
+            ':updated_at': datetime.utcnow().isoformat()
+        }
     )
-    
+
     return {
         'statusCode': 200,
         'body': json.dumps({
             'message': f'{data_type} saved successfully',
-            'iep_id': iep_id
+            'iep_id': iep_id,
+            's3_ref': {'bucket': s3_ref['bucket'], 's3Key': s3_ref['s3Key']}
         }, default=str)
     }
 
 def get_ocr_data(params):
-    """Get OCR data from DynamoDB"""
+    """Get OCR data via its S3 reference (falling back to legacy inline attribute)"""
     iep_id = params['iep_id']
     child_id = params['child_id']
     user_id = params['user_id']
     data_type = params.get('data_type', 'ocr_result')  # 'ocr_result' or 'redacted_ocr_result'
-    
+    _validate_ocr_data_type(data_type)
+
     response = table.get_item(
         Key={
             'iepId': iep_id,
             'childId': child_id
         }
     )
-    
+
     if 'Item' not in response:
         return {
             'statusCode': 404,
             'body': json.dumps({'error': 'Document not found'})
         }
-    
+
     item = response['Item']
-    
+
+    s3_ref = item.get(f'{data_type}_s3_ref')
+    if s3_ref:
+        data = get_content_from_s3(s3_ref['s3Key'], s3_ref['bucket'])
+        if data is None:
+            return {
+                'statusCode': 404,
+                'body': json.dumps({'error': f'{data_type} not found in S3'})
+            }
+        return {
+            'statusCode': 200,
+            'body': json.dumps({'data': data}, default=str)
+        }
+
+    # Legacy documents stored the OCR payload inline on the item
     if data_type not in item:
         return {
             'statusCode': 404,
             'body': json.dumps({'error': f'{data_type} not found'})
         }
-    
+
     return {
         'statusCode': 200,
         'body': json.dumps({
             'data': item[data_type]
+        }, default=str)
+    }
+
+def delete_ocr_data(params):
+    """Delete an OCR payload: the S3 object plus both item attributes.
+
+    Used to purge the raw (unredacted) OCR once redaction has succeeded, and
+    by the failure path so failed documents retain no unredacted content.
+    """
+    iep_id = params['iep_id']
+    child_id = params['child_id']
+    data_type = params.get('data_type', 'ocr_result')
+    _validate_ocr_data_type(data_type)
+
+    response = table.get_item(Key={'iepId': iep_id, 'childId': child_id})
+    item = response.get('Item', {})
+
+    s3_ref = item.get(f'{data_type}_s3_ref')
+    if s3_ref:
+        delete_content_from_s3(s3_ref['s3Key'], s3_ref['bucket'])
+    else:
+        # Delete the conventional key too in case the ref write was lost
+        delete_content_from_s3(get_ocr_s3_key(iep_id, child_id, data_type), os.environ.get('BUCKET', ''))
+
+    table.update_item(
+        Key={
+            'iepId': iep_id,
+            'childId': child_id
+        },
+        UpdateExpression=f"REMOVE {data_type}, {data_type}_s3_ref SET updated_at = :updated_at",
+        ExpressionAttributeValues={
+            ':updated_at': datetime.utcnow().isoformat()
+        }
+    )
+
+    return {
+        'statusCode': 200,
+        'body': json.dumps({
+            'message': f'{data_type} deleted',
+            'iep_id': iep_id
         }, default=str)
     }
 

--- a/lib/chatbot-api/functions/metadata-handler/ddb-service/s3_content_handler.py
+++ b/lib/chatbot-api/functions/metadata-handler/ddb-service/s3_content_handler.py
@@ -48,6 +48,39 @@ def save_content_to_s3(iep_id: str, child_id: str, content: Dict) -> Dict:
         'lastUpdated': datetime.utcnow().isoformat() + 'Z'
     }
 
+def get_ocr_s3_key(iep_id: str, child_id: str, data_type: str) -> str:
+    """Generate S3 key for OCR payloads (raw or redacted)"""
+    return f"iep-data/{iep_id}/{child_id}/{data_type}.json"
+
+def save_ocr_to_s3(iep_id: str, child_id: str, data_type: str, ocr_data) -> Dict:
+    """
+    Save an OCR payload to S3. OCR text routinely exceeds the DynamoDB 400KB
+    item limit (large documents store two copies: raw and redacted), so the
+    payload lives in S3 and only a reference is kept on the item.
+
+    Returns:
+        Dict with s3Key, bucket, size, lastUpdated
+    """
+    s3_key = get_ocr_s3_key(iep_id, child_id, data_type)
+    body = json.dumps(ocr_data, default=str, ensure_ascii=False).encode('utf-8')
+
+    print(f"Saving {data_type} to S3: {s3_key} (size: {len(body)} bytes)")
+
+    s3_client.put_object(
+        Bucket=BUCKET_NAME,
+        Key=s3_key,
+        Body=body,
+        ContentType='application/json',
+        ServerSideEncryption='aws:kms'
+    )
+
+    return {
+        's3Key': s3_key,
+        'bucket': BUCKET_NAME,
+        'size': len(body),
+        'lastUpdated': datetime.utcnow().isoformat() + 'Z'
+    }
+
 def get_content_from_s3(s3_key: str, bucket: str) -> Optional[Dict]:
     """
     Retrieve IEP content from S3

--- a/lib/chatbot-api/functions/metadata-handler/steps/delete_original/handler.py
+++ b/lib/chatbot-api/functions/metadata-handler/steps/delete_original/handler.py
@@ -2,6 +2,7 @@
 Delete the original uploaded file from S3 - Core business logic only
 """
 import json
+import os
 import traceback
 import boto3
 
@@ -40,6 +41,34 @@ def _safe_event_meta(event):
     return {k: event[k] for k in _SAFE_LOG_FIELDS if k in event}
 
 
+def delete_raw_ocr(event):
+    """Delete the raw (unredacted) OCR payload via the centralized DDB service."""
+    lambda_client = boto3.client('lambda')
+    ddb_service_name = event.get('ddb_service_arn') or os.environ.get('DDB_SERVICE_FUNCTION_NAME', 'DDBService')
+
+    ddb_payload = {
+        'operation': 'delete_ocr_data',
+        'params': {
+            'iep_id': event['iep_id'],
+            'user_id': event.get('user_id'),
+            'child_id': event['child_id'],
+            'data_type': 'ocr_result'
+        }
+    }
+
+    ddb_response = lambda_client.invoke(
+        FunctionName=ddb_service_name,
+        InvocationType='RequestResponse',
+        Payload=json.dumps(ddb_payload)
+    )
+
+    ddb_result = json.loads(ddb_response['Payload'].read())
+    if not ddb_result or ddb_result.get('statusCode') != 200:
+        raise Exception(f"Failed to delete raw OCR data: {ddb_result}")
+
+    print("Successfully deleted raw OCR data")
+
+
 def lambda_handler(event, context):
     """
     Delete the original uploaded file from S3.
@@ -52,12 +81,17 @@ def lambda_handler(event, context):
         s3_key = event['s3_key']
         
         print(f"Deleting original file: s3://{s3_bucket}/{s3_key}")
-        
+
         # Delete the original file from S3
         delete_s3_object(s3_bucket, s3_key)
-        
+
         print("Successfully deleted original file")
-        
+
+        # Data-retention: redaction has succeeded by this point and every
+        # downstream step reads redacted_ocr_result only, so the raw
+        # (unredacted) OCR must be purged along with the original document.
+        delete_raw_ocr(event)
+
         return event  # Pass through all input data unchanged
         
     except Exception as e:

--- a/lib/chatbot-api/security.ts
+++ b/lib/chatbot-api/security.ts
@@ -1,0 +1,57 @@
+import * as iam from 'aws-cdk-lib/aws-iam';
+
+/**
+ * Principals allowed to access IEP data (the knowledge S3 bucket and the
+ * DynamoDB tables). This account is shared with other projects and users,
+ * so everything holding IEP data carries an explicit Deny for any principal
+ * not on this list. Identity-based IAM policies cannot override the Deny.
+ *
+ * aws:PrincipalArn resolves assumed-role sessions to the ROLE ARN, so the
+ * role/NAME-* patterns match Lambda/StepFunctions/custom-resource roles for
+ * both environments' stacks.
+ *
+ * Recovery if the allowlist is ever wrong: account root, user/dhruv, or a
+ * CDK redeploy (the cdk bootstrap roles are allowlisted) can always fix it.
+ */
+export function iepDataPrincipalAllowlist(accountId: string): string[] {
+  return [
+    // Account root — never deny root (lockout safety)
+    `arn:aws:iam::${accountId}:root`,
+    // Project owner
+    `arn:aws:iam::${accountId}:user/dhruv`,
+    // Application roles created by the prod and staging stacks
+    `arn:aws:iam::${accountId}:role/AIEPStack-*`,
+    `arn:aws:iam::${accountId}:role/AIEPStagingStack-*`,
+    // CDK bootstrap roles (deploy, file publishing, CloudFormation execution)
+    // used by the GitHub Actions deploys. Note: these are account-wide CDK
+    // roles, so any CDK deployment in this account retains access.
+    `arn:aws:iam::${accountId}:role/cdk-hnb659fds-*`,
+  ];
+}
+
+/**
+ * Explicit Deny for every principal outside the allowlist. AWS service
+ * principals (e.g. S3 log delivery) are exempt — services acting on behalf
+ * of a user still evaluate as that user's role and remain covered.
+ */
+export function createIepDataDenyStatement(
+  accountId: string,
+  actions: string[],
+  resources: string[]
+): iam.PolicyStatement {
+  return new iam.PolicyStatement({
+    sid: 'DenyIepDataOutsideAllowlist',
+    effect: iam.Effect.DENY,
+    principals: [new iam.AnyPrincipal()],
+    actions,
+    resources,
+    conditions: {
+      StringNotLike: {
+        'aws:PrincipalArn': iepDataPrincipalAllowlist(accountId),
+      },
+      Bool: {
+        'aws:PrincipalIsAWSService': 'false',
+      },
+    },
+  });
+}

--- a/lib/chatbot-api/tables/tables.ts
+++ b/lib/chatbot-api/tables/tables.ts
@@ -5,6 +5,8 @@ import * as cdk from 'aws-cdk-lib';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import { getTagProps, tagResource } from '../../tags';
 import * as kms from 'aws-cdk-lib/aws-kms';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import { createIepDataDenyStatement } from '../security';
 
 export interface TableStackProps extends StackProps {
   kmsKey?: kms.IKey;
@@ -25,6 +27,15 @@ export class TableStack extends Stack {
       });
     };
 
+    // Both tables hold FERPA-protected data in a shared AWS account: attach a
+    // resource policy that explicitly denies every principal outside the
+    // IEP-data allowlist (identity-based IAM policies cannot override it).
+    // '*' scopes the deny to the table the policy is attached to (and its
+    // indexes), avoiding a circular reference on the auto-generated ARN.
+    const iepDataResourcePolicy = () => new iam.PolicyDocument({
+      statements: [createIepDataDenyStatement(this.account, ['dynamodb:*'], ['*'])]
+    });
+
     // Create User Profiles Table
     this.userProfilesTable = new dynamodb.Table(scope, 'UserProfilesTable', {
       partitionKey: { name: 'userId', type: dynamodb.AttributeType.STRING },
@@ -33,6 +44,7 @@ export class TableStack extends Stack {
       timeToLiveAttribute: 'ttl',
       encryption: props?.kmsKey ? dynamodb.TableEncryption.CUSTOMER_MANAGED : dynamodb.TableEncryption.AWS_MANAGED,
       ...(props?.kmsKey ? { encryptionKey: props.kmsKey } : {}),
+      resourcePolicy: iepDataResourcePolicy(),
     });
     tagTable(this.userProfilesTable, 'UserProfilesTable');
 
@@ -45,6 +57,7 @@ export class TableStack extends Stack {
       timeToLiveAttribute: 'ttl',
       encryption: props?.kmsKey ? dynamodb.TableEncryption.CUSTOMER_MANAGED : dynamodb.TableEncryption.AWS_MANAGED,
       ...(props?.kmsKey ? { encryptionKey: props.kmsKey } : {}),
+      resourcePolicy: iepDataResourcePolicy(),
     });
     tagTable(this.iepDocumentsTable, 'IepDocumentsTable');
 

--- a/lib/user-interface/app/src/pages/iep-folder/IEPSummarizationAndTranslation.tsx
+++ b/lib/user-interface/app/src/pages/iep-folder/IEPSummarizationAndTranslation.tsx
@@ -811,11 +811,6 @@ const IEPSummarizationAndTranslation: React.FC = () => {
     );
   }
 
-  // If document fails the user is taken to the upload screen
-  if (document && document.status === "FAILED") {
-    navigate('/iep-documents');
-  }
-
   // Processed Container - when document is processed, failed, or in other states
   return (
     <>
@@ -884,8 +879,15 @@ const IEPSummarizationAndTranslation: React.FC = () => {
                       <Alert variant="danger">
                         <h5>{t('summary.failed.title')}</h5>
                         <p>{t('summary.failed.message')}</p>
+                        <Button
+                          variant="primary"
+                          size="sm"
+                          onClick={() => navigate('/iep-documents')}
+                        >
+                          {t('summary.reuploadButton')}
+                        </Button>
                       </Alert>
-                    ) : 
+                    ) :
                       <>
                         {/* Show prominent alert when preferred language content is missing (shown at the top) */}
                         {preferredLanguage !== 'en' && !hasContent(preferredLanguage) && hasContent('en') && (


### PR DESCRIPTION
Cherry-picks the remaining staging work onto `main`, **except** the TTS feature (590b600), which stays in staging for now. (The phone OTP fix originally included here landed separately via #51 and is already live in prod.)

## Included (in original order)

- **07a0163** ci: cache CDK Docker-bundled assets between deploys. Prod deploys get the same cdk.out caching staging has; the first run after merge populates the cache, later runs skip Docker bundling for unchanged lambdas.
- **0c18299** fix: large-document processing, data retention, and IEP data lockdown. OCR payloads move to S3 (fixes the 400KB DynamoDB limit on large IEPs), raw OCR is purged after redaction, FAILED documents get a proper re-upload UI, and the knowledge bucket + tables gain the explicit deny outside the IEP-data allowlist (the allowlist already covers `AIEPStack-*` roles).
- **855c4b5** fix: expire noncurrent S3 versions so deleted IEP artifacts are actually gone.

## Verification

- The branch differs from `staging` by exactly the 15 TTS files and nothing else (`git diff prod-sync-2026-07-24 origin/staging --stat`), so merging it makes prod = staging minus TTS.
- All cherry-picks applied without conflicts; none reference TTS code, and the re-upload button's translation key already exists on `main`.
- `tsc --noEmit` clean for both the frontend app and the CDK code; `ENVIRONMENT=production cdk synth AIEPStack` succeeds.
- All three changes have been running on staging since July 7.

## Notes

- TTS lands later via a normal staging -> main merge; because these are cherry-picks (identical content), that future merge stays clean.
- Merging this PR auto-deploys prod via `deploy.yml` (push to `main`).
- The head branch is temporary; delete it after merging (repo target state: only `staging` and `main`).