### PR TITLE
prod: nightly Slack digest + ownerless-document purge mode

### DIFF
--- a/.github/workflows/e2e_staging.yml
+++ b/.github/workflows/e2e_staging.yml
@@ -12,6 +12,10 @@ on:
         description: 'Also run the @pipeline document-upload spec (slow, costs LLM calls)'
         type: boolean
         default: false
+      notify_slack:
+        description: 'Post a result digest to Slack (needs the SLACK_WEBHOOK_URL secret)'
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -78,3 +82,74 @@ jobs:
             e2e/playwright-report
             e2e/test-results
           retention-days: 7
+
+      # Nightly digest. Runs on success AND failure, because "it passed again"
+      # is the message that makes a silent break noticeable: the 2026-07 signup
+      # outage went a month unnoticed precisely because nothing reported in.
+      #
+      # Deliberately a plain curl rather than a third-party action: this posts
+      # a credential-bearing URL, and the repo is public.
+      - name: Post result digest to Slack
+        if: always() && inputs.notify_slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          RESULT: ${{ job.status }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          PIPELINE: ${{ inputs.run_pipeline && 'included' || 'skipped' }}
+        run: |
+          set -uo pipefail
+          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
+            echo "SLACK_WEBHOOK_URL is not set; skipping the digest."
+            echo "Add it as a repository secret to turn this on."
+            exit 0
+          fi
+
+          # Summarize from Playwright's own JSON so the message reflects the
+          # run rather than a parsed log. Missing/short file means the suite
+          # died before reporting, which the fallback text says plainly.
+          summary=$(node -e '
+            const fs = require("fs");
+            try {
+              const r = JSON.parse(fs.readFileSync("results.json", "utf8"));
+              const tests = [];
+              const walk = (suite) => {
+                for (const spec of suite.specs ?? []) {
+                  const status = spec.tests?.[0]?.results?.slice(-1)[0]?.status ?? "unknown";
+                  tests.push({ title: `${(spec.file ?? "").replace(/^.*\//, "")} › ${spec.title}`, status, ok: spec.ok });
+                }
+                for (const child of suite.suites ?? []) walk(child);
+              };
+              for (const suite of r.suites ?? []) walk(suite);
+              const passed = tests.filter((t) => t.ok && t.status !== "skipped").length;
+              const skipped = tests.filter((t) => t.status === "skipped").length;
+              const failed = tests.filter((t) => !t.ok && t.status !== "skipped");
+              let out = `${passed} passed, ${failed.length} failed, ${skipped} skipped`;
+              if (failed.length) {
+                out += "\n" + failed.map((t) => `• ${t.title}`).join("\n");
+              }
+              process.stdout.write(out);
+            } catch (err) {
+              process.stdout.write("could not read results.json (the suite may have failed before reporting)");
+            }
+          ')
+
+          if [ "$RESULT" = "success" ]; then
+            header=":white_check_mark: A-IEP nightly E2E passed"
+          else
+            header=":x: A-IEP nightly E2E failed"
+          fi
+
+          # jq -Rs builds a correctly escaped JSON string from arbitrary text.
+          payload=$(jq -n \
+            --arg text "$(printf '%s\n%s\n\nDocument pipeline: %s\n<%s|View run>' "$header" "$summary" "$PIPELINE" "$RUN_URL")" \
+            '{text: $text}')
+
+          # Never echo the URL: it is the credential.
+          code=$(curl -sS -o /tmp/slack_response -w '%{http_code}' \
+            -X POST -H 'Content-type: application/json' \
+            --data "$payload" "$SLACK_WEBHOOK_URL" || echo "000")
+          echo "Slack responded HTTP $code: $(cat /tmp/slack_response)"
+          # A broken notifier must not turn a green suite red.
+          if [ "$code" != "200" ]; then
+            echo "::warning::Slack digest failed to post (HTTP $code)"
+          fi

--- a/.github/workflows/nightly_e2e.yml
+++ b/.github/workflows/nightly_e2e.yml
@@ -23,3 +23,7 @@ jobs:
     secrets: inherit
     with:
       run_pipeline: ${{ github.event_name == 'schedule' || inputs.run_pipeline }}
+      # The daily report into #a-iep-dev, pass or fail. Needs the
+      # SLACK_WEBHOOK_URL repository secret; without it the step logs that it
+      # skipped and the run still passes.
+      notify_slack: true

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -2,4 +2,6 @@
 # the HTML report under playwright-report; CI uploads them only on failure)
 test-results/
 playwright-report/
+# Machine-readable run summary; the nightly Slack digest reads it in CI
+results.json
 node_modules/

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -31,7 +31,14 @@ export default defineConfig({
   expect: { timeout: 15_000 },
 
   forbidOnly: !!process.env.CI,
-  reporter: [['list'], ['html', { open: 'never' }]],
+  // json feeds the nightly Slack digest (.github/workflows/e2e_staging.yml
+  // reads results.json); list is for humans reading CI logs, html for the
+  // artifact uploaded on failure.
+  reporter: [
+    ['list'],
+    ['html', { open: 'never' }],
+    ['json', { outputFile: 'results.json' }],
+  ],
 
   use: {
     trace: 'on-first-retry',

--- a/scripts/recover-orphaned-documents.py
+++ b/scripts/recover-orphaned-documents.py
@@ -105,6 +105,7 @@ def discover(env):
 
     resolved = {
         'documents_table': find_one(table_names, prefix, 'IepDocumentsTable', forbid=forbid),
+        'profiles_table': find_one(table_names, prefix, 'UserProfilesTable', forbid=forbid),
         # CloudFormation truncates generated names, so match on prefixes short
         # enough to survive it ('CheckLanguagePrefsFunction' arrives as
         # 'CheckLanguagePre-<suffix>').
@@ -224,6 +225,136 @@ def recover_one(item, res, verbose=True):
     return True, f'rebuilt, {head["ContentLength"]} bytes, languages={targets or ["en"]}'
 
 
+def purge_one(item, res):
+    """
+    Delete an unrecoverable document record so the app offers a clean upload
+    screen instead of an empty summary.
+
+    Removing only contentS3Reference would not achieve that: the profile
+    handler falls back to the legacy inline path and still returns a document
+    with empty content, so the parent keeps seeing a blank summary. The record
+    itself has to go for the child to read as having no document.
+
+    Refuses anything that still holds OCR text (that would be recoverable) or
+    whose pointer is the live bucket (that one is healthy).
+    """
+    iep_id, child_id = item['iepId'], item['childId']
+    ref = item.get('contentS3Reference') or {}
+    if ref.get('bucket') == res['live_bucket']:
+        return False, 'pointer is healthy; refusing to delete'
+    if any('ocr' in k.lower() for k in item):
+        return False, 'item still holds OCR text; recover it instead of deleting'
+
+    # Sweep any objects still sitting in the LIVE bucket for this document
+    # (cached audio, stray content) so nothing dangles after the record goes.
+    removed_objects = 0
+    for prefix in (f'iep-audio/{iep_id}/', f'iep-data/{iep_id}/'):
+        token = None
+        while True:
+            kwargs = {'Bucket': res['live_bucket'], 'Prefix': prefix}
+            if token:
+                kwargs['ContinuationToken'] = token
+            listing = s3.list_objects_v2(**kwargs)
+            keys = [{'Key': o['Key']} for o in listing.get('Contents', [])]
+            if keys:
+                s3.delete_objects(Bucket=res['live_bucket'], Delete={'Objects': keys})
+                removed_objects += len(keys)
+            token = listing.get('NextContinuationToken')
+            if not token:
+                break
+
+    table = dynamodb.Table(res['documents_table'])
+    table.delete_item(Key={'iepId': iep_id, 'childId': child_id})
+
+    still_there = table.get_item(
+        Key={'iepId': iep_id, 'childId': child_id},
+        ProjectionExpression='iepId',
+    ).get('Item')
+    if still_there:
+        return False, 'delete did not take effect'
+    return True, f'record deleted, {removed_objects} live-bucket object(s) swept'
+
+
+def find_ownerless(res):
+    """
+    Documents whose child exists in no profile, so no user can ever open them.
+
+    These predate the upload path writing userId onto the record. Account
+    deletion finds a user's documents through the byUserId GSI, and DynamoDB
+    does not index items missing that attribute, so a userId-less record is
+    invisible to deletion and outlives the account it belonged to. Current
+    uploads always set userId, so nothing new joins this set.
+    """
+    profiles = dynamodb.Table(res['profiles_table'])
+    owned, kwargs = set(), {'ProjectionExpression': 'children'}
+    while True:
+        page = profiles.scan(**kwargs)
+        for profile in page.get('Items', []):
+            for child in profile.get('children') or []:
+                child_id = (child or {}).get('childId')
+                if child_id:
+                    owned.add(child_id)
+        if 'LastEvaluatedKey' not in page:
+            break
+        kwargs['ExclusiveStartKey'] = page['LastEvaluatedKey']
+
+    # Without this guard a failed or empty profile scan would make EVERY
+    # document look ownerless, and this function feeds a delete.
+    if not owned:
+        raise SystemExit(
+            'the profiles table returned no children at all; refusing to treat '
+            'every document as ownerless'
+        )
+
+    documents = scan_documents(res['documents_table'])
+    ownerless = [d for d in documents if d['childId'] not in owned]
+
+    # Second guard: this set is meant to be a handful of legacy records. If it
+    # is most of the table, the comparison is wrong, not the data.
+    if documents and len(ownerless) > len(documents) // 2:
+        raise SystemExit(
+            f'{len(ownerless)} of {len(documents)} documents look ownerless, which is '
+            'implausible; refusing to delete on a comparison this suspect'
+        )
+    return ownerless, len(documents)
+
+
+def purge_ownerless_one(item, res):
+    """
+    Delete an unreachable document, content and cached audio included.
+
+    Unlike purge_one this does NOT refuse items holding OCR text: with no
+    profile owning the child there is nobody to show a rebuilt summary to, so
+    the surviving text is retained PII rather than recoverable material.
+    """
+    iep_id, child_id = item['iepId'], item['childId']
+
+    removed_objects = 0
+    for prefix in (f'iep-audio/{iep_id}/', f'iep-data/{iep_id}/'):
+        token = None
+        while True:
+            kwargs = {'Bucket': res['live_bucket'], 'Prefix': prefix}
+            if token:
+                kwargs['ContinuationToken'] = token
+            listing = s3.list_objects_v2(**kwargs)
+            keys = [{'Key': o['Key']} for o in listing.get('Contents', [])]
+            if keys:
+                s3.delete_objects(Bucket=res['live_bucket'], Delete={'Objects': keys})
+                removed_objects += len(keys)
+            token = listing.get('NextContinuationToken')
+            if not token:
+                break
+
+    table = dynamodb.Table(res['documents_table'])
+    table.delete_item(Key={'iepId': iep_id, 'childId': child_id})
+    if table.get_item(Key={'iepId': iep_id, 'childId': child_id},
+                      ProjectionExpression='iepId').get('Item'):
+        return False, 'delete did not take effect'
+    had_ocr = any('ocr' in k.lower() for k in item)
+    return True, (f'record deleted (held OCR: {had_ocr}), '
+                  f'{removed_objects} live-bucket object(s) swept')
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__,
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -232,11 +363,55 @@ def main():
                         help='actually rebuild (default is a dry run)')
     parser.add_argument('--iep-id', help='recover only this document')
     parser.add_argument('--limit', type=int, help='recover at most N documents')
+    parser.add_argument('--purge-unrecoverable', action='store_true',
+                        help='instead of rebuilding, DELETE the records whose content '
+                             'cannot be rebuilt, so the app shows the upload screen '
+                             'rather than a permanently empty summary')
+    parser.add_argument('--purge-ownerless', action='store_true',
+                        help='DELETE documents whose child exists in no profile. These '
+                             'predate the upload path writing userId, so account '
+                             'deletion (which queries the byUserId GSI) could never '
+                             'see them; nobody can open them and any text they hold '
+                             'is retained PII')
     args = parser.parse_args()
 
     res = discover(args.env)
     print(f'env={args.env}  bucket={res["live_bucket"]}')
     print(f'table={res["documents_table"]}')
+
+    if args.purge_ownerless:
+        ownerless, total = find_ownerless(res)
+        print(f'\n{total} documents, {len(ownerless)} owned by no profile')
+        if args.iep_id:
+            ownerless = [i for i in ownerless if i['iepId'] == args.iep_id]
+        if args.limit:
+            ownerless = ownerless[:args.limit]
+        if not ownerless:
+            print('nothing to purge.')
+            return 0
+
+        if not args.apply:
+            print('\nDRY RUN. Would DELETE these unreachable records '
+                  '(content and cached audio included):')
+            for item in ownerless:
+                held_ocr = any('ocr' in k.lower() for k in item)
+                print(f'    {item["iepId"]}  (child {item["childId"]}, held OCR: {held_ocr})')
+            print('\nRe-run with --apply to delete. This is not reversible.')
+            return 0
+
+        print(f'\nDeleting {len(ownerless)} unreachable record(s)...')
+        failures = []
+        for index, item in enumerate(ownerless, start=1):
+            print(f'  [{index}/{len(ownerless)}] {item["iepId"]}', flush=True)
+            try:
+                ok, message = purge_ownerless_one(item, res)
+            except Exception as err:  # noqa: BLE001 - report and continue
+                ok, message = False, str(err)[:300]
+            print(f'    {"OK" if ok else "FAILED"}: {message}', flush=True)
+            if not ok:
+                failures.append((item['iepId'], message))
+        print(f'\ndone: {len(ownerless) - len(failures)} deleted, {len(failures)} failed')
+        return 1 if failures else 0
 
     items = scan_documents(res['documents_table'])
     recoverable, lost, healthy = classify(items, res['live_bucket'])
@@ -247,6 +422,40 @@ def main():
         print('  unrecoverable (no redacted OCR survives; the parent must re-upload):')
         for item in lost:
             print(f'    {item["iepId"]}')
+
+    if args.purge_unrecoverable:
+        targets = lost
+        if args.iep_id:
+            targets = [i for i in lost if i['iepId'] == args.iep_id]
+        if args.limit:
+            targets = targets[:args.limit]
+
+        if not targets:
+            print('\nnothing to purge.')
+            return 0
+        if not args.apply:
+            print(f'\nDRY RUN. Would DELETE {len(targets)} unrecoverable record(s), '
+                  'after which the affected children show the upload screen:')
+            for item in targets:
+                print(f'    {item["iepId"]}  (child {item["childId"]})')
+            print('\nRe-run with --apply to delete. This is not reversible.')
+            return 0
+
+        print(f'\nDeleting {len(targets)} unrecoverable record(s)...')
+        failures = []
+        for index, item in enumerate(targets, start=1):
+            print(f'  [{index}/{len(targets)}] {item["iepId"]}', flush=True)
+            try:
+                ok, message = purge_one(item, res)
+            except Exception as err:  # noqa: BLE001 - report and continue
+                ok, message = False, str(err)[:300]
+            print(f'    {"OK" if ok else "REFUSED"}: {message}', flush=True)
+            if not ok:
+                failures.append((item['iepId'], message))
+        print(f'\ndone: {len(targets) - len(failures)} deleted, {len(failures)} refused')
+        for iep_id, message in failures:
+            print(f'  REFUSED {iep_id}: {message}')
+        return 1 if failures else 0
 
     targets = recoverable
     if args.iep_id:


### PR DESCRIPTION
Small follow-up promotion: the nightly Slack digest and the ownerless-document purge mode. **Additions only, no deletions** (verified: the diff against main is 5 files, +298/-1).

## Why this is needed

GitHub runs `schedule` events from the **default branch**, so the nightly digest cannot fire until this wiring is on `main`. This morning's 09:00 run executed from `main` and passed silently; the digest only worked when I dispatched it manually against `staging`.

## What's in it

**Nightly Slack digest** (`#a-iep-dev`). Posts on success as well as failure, because a nightly that goes quiet is itself the signal: the 2026-07 signup outage hid for a month precisely because nothing reported in. Playwright gains a `json` reporter and the workflow summarizes from that rather than scraping the log, naming failed journeys with a link to the run.

Gated behind a `notify_slack` input, so only the nightly is chatty; the per-deploy E2E stays quiet since a deploy failure is already visible. Posting is a plain `curl` (the URL is a credential and this repo is public, so no third-party action touches it), the URL is never echoed, and a failed post only warns rather than failing a green suite. Without the `SLACK_WEBHOOK_URL` secret the step logs that it skipped and the run still passes.

**`--purge-ownerless`** on the recovery script: deletes documents whose child exists in no profile. Those predate the upload path writing `userId`, and since account deletion queries the `byUserId` GSI (which does not index items missing that attribute), they were invisible to deletion and outlived their accounts. Two guards, because the selection feeds a delete: it refuses if the profiles scan yields no children, and refuses if more than half the table matches.

## Verified end to end

Dispatched the nightly manually against `staging` with the secret in place: **`Slack responded HTTP 200: ok`**, and the digest landed in `#a-iep-dev` reading `6 passed, 0 failed, 9 skipped`. The webhook shows as `***` in the public build log. Also tested the failure path against a synthetic results file (names the failed spec, escapes quotes and angle brackets), plus the missing-secret and corrupt-results paths.

`npm test` 171 passing, root and frontend typechecks clean, full frontend lint clean, both stacks synth.

## Note on the branch state

This PR follows a back-merge of `main` into `staging` (`2dc8c47`). `main` carried the production feature gating that `staging` lacked, so a plain staging-into-main merge would have **deleted the gating and switched TTS, referrals and the name step back on in production**. Merging main into staging first converged them; staging's own behaviour is unchanged because the gate resolves per environment (staging still enables all three, confirmed by its synth still carrying the E2E backdoor and CustomSMSSender).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Slack result digests for staging and nightly end-to-end test runs, including run status and test summaries.
  * Added JSON test reporting for improved run visibility.

* **Maintenance**
  * Added tools to safely identify and remove unrecoverable or ownerless document records and associated stored data.
  * Included dry-run controls, filtering, limits, and safety checks to prevent accidental deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->