### PR TITLE
Promote to production: carousel height, divider copy, Account Center order

### DIFF
--- a/lib/user-interface/app/src/components/ParentRightsCarousel.css
+++ b/lib/user-interface/app/src/components/ParentRightsCarousel.css
@@ -120,7 +120,11 @@
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
-  min-height: 240px;
+  /* Exactly the 200px of .parent-rights-card. This was min-height: 240px,
+     which made the deck 40px taller on the four tutorial slides and shifted
+     the indicator dots again on the way in and out of them. Every card type
+     is now the same height, so nothing below the carousel moves. */
+  height: 200px;
   border-radius: 12px;
   border: 1px solid #1E1E1E;
   margin-top: 20px;
@@ -208,11 +212,15 @@
   color: #6c757d;
 }
 
-/* A divider carries its title and image in the card above and no body copy,
-   so its text block collapses rather than leaving a 228px void above the
-   dots. Declared after .slide-rights-content so it wins the height. */
+/* A divider's text block stays EXACTLY as tall as every other slide's, even
+   though it is empty. It used to collapse to 3rem, which shortened the whole
+   slide by ~180px and made the indicator dots jump up and down as a parent
+   swiped past each of the three dividers. A carousel whose controls move under
+   the thumb is hard to use, and that costs more than the empty space this
+   leaves. The class is kept as a hook: the suite asserts a divider renders no
+   body copy through it. */
 .slide-rights-content--section {
-  height: 3rem;
+  height: 228px;
 }
 
 

--- a/lib/user-interface/app/src/pages/profile/AccountCenter.tsx
+++ b/lib/user-interface/app/src/pages/profile/AccountCenter.tsx
@@ -82,11 +82,6 @@ const AccountCenter: React.FC = () => {
       title: t("accountCenter.changeLanguage"),
       testId: "account-center-change-language",
     },
-    {
-      id: "2",
-      title: t("accountCenter.deleteAccount"),
-      testId: "account-center-delete-account",
-    },
     // The only in-app entry point to the referral flow, so this row is what
     // keeps referrals dark where the feature is off (prod). The /invite route
     // itself stays registered, and the ?ref= capture keeps running: neither is
@@ -101,6 +96,15 @@ const AccountCenter: React.FC = () => {
     // Internal console entry, rendered only for members of the Cognito
     // admin group (the backend re-checks the claim on every admin API call)
     ...(isAdmin ? [{ id: "5", title: "Admin Console", testId: "account-center-admin-console" }] : []),
+    // Deliberately last but one, directly above Log out. Deleting an account
+    // is irreversible and it used to sit above the everyday rows, where a
+    // mistap costs a parent their documents. Ids are unchanged so the E2E
+    // hooks and any stored accordion state still resolve.
+    {
+      id: "2",
+      title: t("accountCenter.deleteAccount"),
+      testId: "account-center-delete-account",
+    },
     {
       id: "4",
       title: t("accountCenter.logOut"),

--- a/lib/user-interface/app/src/translations/ar.json
+++ b/lib/user-interface/app/src/translations/ar.json
@@ -323,7 +323,7 @@
 
     "carousel.section.whatAiepDoes": "ما يفعله AIEP",
     "carousel.section.yourRights": "حقوقك",
-    "carousel.section.whatYouWillSeeNext": "ما ستراه بعد ذلك",
+    "carousel.section.whatYouWillSeeNext": "أين تجد كل شيء",
     "carousel.rights.indicator": "{number}. {title}",
 
     "appTutorial.slide1.title": "ماذا نفعل الآن؟",

--- a/lib/user-interface/app/src/translations/en.json
+++ b/lib/user-interface/app/src/translations/en.json
@@ -326,7 +326,7 @@
 
     "carousel.section.whatAiepDoes": "What AIEP does",
     "carousel.section.yourRights": "Your Rights",
-    "carousel.section.whatYouWillSeeNext": "What you'll see next",
+    "carousel.section.whatYouWillSeeNext": "Where to find things",
     "carousel.rights.indicator": "{number}. {title}",
 
     "appTutorial.slide1.title": "What are we doing right now?",

--- a/lib/user-interface/app/src/translations/es.json
+++ b/lib/user-interface/app/src/translations/es.json
@@ -314,7 +314,7 @@
 
     "carousel.section.whatAiepDoes": "Lo que hace AIEP",
     "carousel.section.yourRights": "Sus derechos",
-    "carousel.section.whatYouWillSeeNext": "Lo que verá a continuación",
+    "carousel.section.whatYouWillSeeNext": "Dónde encontrar cada cosa",
     "carousel.rights.indicator": "{number}. {title}",
 
     "appTutorial.slide1.title": "¿Qué estamos haciendo ahora?",

--- a/lib/user-interface/app/src/translations/vi.json
+++ b/lib/user-interface/app/src/translations/vi.json
@@ -319,7 +319,7 @@
 
     "carousel.section.whatAiepDoes": "AIEP làm gì",
     "carousel.section.yourRights": "Quyền của bạn",
-    "carousel.section.whatYouWillSeeNext": "Những gì bạn sẽ thấy tiếp theo",
+    "carousel.section.whatYouWillSeeNext": "Tìm mọi thứ ở đâu",
     "carousel.rights.indicator": "{number}. {title}",
 
     "appTutorial.slide1.title": "Chúng tôi đang làm gì ngay bây giờ?",

--- a/lib/user-interface/app/src/translations/zh.json
+++ b/lib/user-interface/app/src/translations/zh.json
@@ -312,7 +312,7 @@
 
     "carousel.section.whatAiepDoes": "AIEP 的作用",
     "carousel.section.yourRights": "您的权利",
-    "carousel.section.whatYouWillSeeNext": "接下来您会看到什么",
+    "carousel.section.whatYouWillSeeNext": "在哪里找到各项内容",
     "carousel.rights.indicator": "{number}. {title}",
 
     "appTutorial.slide1.title": "我们现在在做什么？",


### PR DESCRIPTION
Carries the one commit that landed on `staging` just after #57 was merged, so it missed that promotion. Everything here is UI polish from last night's staging testing; no backend, infrastructure, or auth changes.

Staging is green: CI, deploy, post-deploy smoke test and E2E journeys all passed on this commit.

## What ships

**The carousel indicator dots stopped moving while swiping.** Slide height varied by slide type in two independent places:

- A divider's text block collapsed to `3rem` against every other slide's `228px`, a ~180px jump hit three times per lap.
- The four tutorial slides sat on a card with `min-height: 240px` against the other three types' hard `200px`, a further 40px jump on the way in and out of them.

Both are uniform now, so nothing below the carousel shifts. The divider keeps an empty `228px` block deliberately: a control that moves under the thumb costs a parent more than the whitespace does.

**The third divider reads "Where to find things"** instead of "What you'll see next". It describes the four slides that follow it more plainly, and avoids an idiom for the four non-English locales. Translated in all five.

**Account Center moves Delete Account to last but one**, directly above Log out. It previously sat above the everyday rows, where a mistap costs a parent their documents. Ids and testIds are unchanged, so the E2E hooks still resolve.

## Test plan

- [x] 111 frontend tests, 256 jest, full lint at `--max-warnings 0`, typechecks and build
- [x] CI, deploy, post-deploy smoke test and E2E journeys green on staging for this commit

**Worth an eyeball on a device after deploy, because CSS layout is not observable in jsdom** — nothing in the suite can catch a height regression here, so the parity rests on reading the rules:

- [ ] Swipe a full lap of the 15-slide carousel; the dots hold still through all three dividers and through the tutorial slides
- [ ] The four tutorial slides still look right, since their card lost 40px of height
- [ ] Account Center order reads: Update profile, Change language, Invite, (Admin), Delete account, Log out

## Not addressed here

Both predate this work and are unchanged:

- The rights cards render cream headings on a light pink background, roughly **1.3:1 contrast**, effectively illegible. Affects all six rights slides.
- `AdminReferrals` still uses the icon web font, and two of its buttons are icon-only, so they are blank under iOS Lockdown Mode. Same root cause as the invite page fix already in production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Adjusted tutorial cards and section dividers for more consistent sizing and layout.
  * Moved the account deletion option closer to the Log out action for improved account management flow.

* **Localization**
  * Updated the carousel navigation label to “Where to find things” in English, Arabic, Spanish, Vietnamese, and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->