### PR TITLE
Promote to production: carousel divider copy and a date-format note

### DIFF
--- a/lib/user-interface/app/src/common/helpers/text-helper.ts
+++ b/lib/user-interface/app/src/common/helpers/text-helper.ts
@@ -39,7 +39,15 @@ export abstract class TextHelper {
     // Convert Unix timestamp (seconds) to milliseconds for JavaScript Date
     const date = new Date(timestamp * 1000);
     
-    // Format the date based on locale
+    // Format the date based on locale.
+    //
+    // Vietnamese renders as "5 tháng 8, 2026". That comma looks anglicized
+    // next to the other locales, and written Vietnamese normally joins the
+    // year with "năm" ("5 tháng 8 năm 2026"). It is NOT a bug: `d MMMM, y` is
+    // CLDR's own long-date pattern for vi, so this is what Android, iOS and
+    // Chrome all show, and matching the rest of a parent's phone was judged
+    // worth more than the more formal wording. Reviewed and kept deliberately;
+    // do not special-case it without a native speaker asking for the change.
     const options: Intl.DateTimeFormatOptions = {
       year: 'numeric',
       month: 'long',

--- a/lib/user-interface/app/src/components/ParentRightsCarousel.test.tsx
+++ b/lib/user-interface/app/src/components/ParentRightsCarousel.test.tsx
@@ -182,12 +182,30 @@ describe("the section dividers", () => {
     expect(screen.getByTestId("carousel-active-slide")).toHaveClass("parent-rights-card--blue");
   });
 
-  test("every divider's text block is empty", () => {
-    const { container } = renderCarousel();
+  test("every divider's text block carries the hint, not its repeated title", () => {
+    // The block has to hold its full height or the indicator dots move under
+    // the parent's thumb, so it shows the hint rather than sitting empty. It
+    // must NOT repeat the divider's title, which is already in the card above.
+    const { container } = renderCarousel({ sectionHint: "Swipe to learn more" });
 
     const dividerText = container.querySelectorAll(".slide-rights-content--section");
     expect(dividerText).toHaveLength(3);
-    dividerText.forEach((block) => expect(block).toBeEmptyDOMElement());
+    dividerText.forEach((block) => {
+      expect(block).toHaveTextContent("Swipe to learn more");
+      expect(block.querySelector("h1, h2")).toBeNull();
+    });
+  });
+
+  test("the hint never names a side, because RTL mirrors the arrows", () => {
+    // The app sets document.dir and this carousel flips its own buttons under
+    // RTL, so in Arabic "next" sits on the LEFT. Copy naming a side would send
+    // Arabic readers the wrong way; the shipped strings say "the arrows".
+    const sides = /\b(right|left|derecha|izquierda|phải|trái|右|左|يمين|يسار)\b/;
+    for (const [code, dict] of Object.entries({ en, es, zh, vi, ar })) {
+      const hint = (dict as Record<string, string>)["carousel.section.hint"];
+      expect(hint, `${code} hint must exist`).toBeTruthy();
+      expect(hint, `${code} hint must not name a side: ${hint}`).not.toMatch(sides);
+    }
   });
 });
 

--- a/lib/user-interface/app/src/components/ParentRightsCarousel.tsx
+++ b/lib/user-interface/app/src/components/ParentRightsCarousel.tsx
@@ -135,6 +135,10 @@ export type SectionTheme = (typeof SECTION_THEMES)[number];
  */
 const DEFAULT_RIGHTS_INDICATOR_TEMPLATE = '{number}. {title}';
 
+// Fallback for the standalone /rights-of-parents route, which mounts this
+// component with no props and no translator.
+const DEFAULT_SECTION_HINT = 'Swipe or tap the arrows to learn more';
+
 export interface ParentRightsCarouselProps {
   slides?: SlideData[];
   className?: string;
@@ -153,6 +157,16 @@ export interface ParentRightsCarouselProps {
    */
   loop?: boolean;
   rightsIndicatorTemplate?: string;
+  /**
+   * Body copy for a section divider, which has no content of its own. It fills
+   * what would otherwise be an empty block and tells a parent how to move on.
+   *
+   * Deliberately says "the arrows" rather than naming a side: the app sets
+   * document.dir, and this carousel mirrors its own buttons under RTL, so in
+   * Arabic "next" sits on the LEFT. Naming a side would point Arabic readers
+   * the wrong way.
+   */
+  sectionHint?: string;
 }
 
 const ParentRightsCarousel: React.FC<ParentRightsCarouselProps> = ({
@@ -162,6 +176,7 @@ const ParentRightsCarousel: React.FC<ParentRightsCarouselProps> = ({
   headerGreenTitle = 'Your data is safe with us',
   loop = true,
   rightsIndicatorTemplate = DEFAULT_RIGHTS_INDICATOR_TEMPLATE,
+  sectionHint = DEFAULT_SECTION_HINT,
 }) => {
 
   const [activeIndex, setActiveIndex] = useState(0);
@@ -283,9 +298,14 @@ const ParentRightsCarousel: React.FC<ParentRightsCarouselProps> = ({
             <Carousel.Item key={slide.id}>
               <div className={`carousel-slide slide-${index + 1}`}>
                 {slide.type === 'section' ? (
-                  // A divider is title + image only: its title is the card
-                  // above, and repeating it here would say the same thing twice.
-                  <div className="slide-rights-content slide-rights-content--section" />
+                  // A divider's title lives in the card above, so repeating it
+                  // here would say the same thing twice. The block still has to
+                  // hold its full height (anything shorter moves the indicator
+                  // dots under the parent's thumb), so it carries the hint
+                  // rather than sitting empty.
+                  <div className="slide-rights-content slide-rights-content--section">
+                    <p>{sectionHint}</p>
+                  </div>
                 ) : (
                   <div className="slide-rights-content">
                     {/* A right is headed by its own number and title — the one

--- a/lib/user-interface/app/src/components/ProcessingModal.tsx
+++ b/lib/user-interface/app/src/components/ProcessingModal.tsx
@@ -14,6 +14,7 @@ interface ProcessingModalProps {
   headerGreenTitle: string;
   /** e.g. "{number}. {title}", localized by the page that owns t(). */
   rightsIndicatorTemplate: string;
+  sectionHint: string;
 }
 
 const ProcessingModal: React.FC<ProcessingModalProps> = ({
@@ -24,6 +25,7 @@ const ProcessingModal: React.FC<ProcessingModalProps> = ({
   headerPinkTitle,
   headerGreenTitle,
   rightsIndicatorTemplate,
+  sectionHint,
 }) => {
   return (
     // Stable E2E hook: "the pipeline is running" is a milestone the document
@@ -51,6 +53,7 @@ const ProcessingModal: React.FC<ProcessingModalProps> = ({
                   headerPinkTitle={headerPinkTitle}
                   headerGreenTitle={headerGreenTitle}
                   rightsIndicatorTemplate={rightsIndicatorTemplate}
+                  sectionHint={sectionHint}
                 />
               </div>
             </Card.Body>

--- a/lib/user-interface/app/src/pages/iep-folder/IEPSummarizationAndTranslation.tsx
+++ b/lib/user-interface/app/src/pages/iep-folder/IEPSummarizationAndTranslation.tsx
@@ -1025,6 +1025,7 @@ const IEPSummarizationAndTranslation: React.FC = () => {
         headerPinkTitle={t('rights.header.title.pink')}
         headerGreenTitle={t('rights.header.title.green')}
         rightsIndicatorTemplate={t('carousel.rights.indicator')}
+        sectionHint={t('carousel.section.hint')}
       />
     );
   }

--- a/lib/user-interface/app/src/translations/ar.json
+++ b/lib/user-interface/app/src/translations/ar.json
@@ -321,6 +321,7 @@
     "privacy.slide2.title": "نحن نهتم بخصوصيتك",
     "privacy.slide2.content": "نقوم بإزالة معلوماتك الشخصية من الملخصات، ولن نخزّن أي بيانات شخصية تخصك أو تخص طفلك.",
 
+    "carousel.section.hint": "اسحب أو اضغط على الأسهم لمعرفة المزيد",
     "carousel.section.whatAiepDoes": "ما يفعله AIEP",
     "carousel.section.yourRights": "حقوقك",
     "carousel.section.whatYouWillSeeNext": "أين تجد كل شيء",

--- a/lib/user-interface/app/src/translations/en.json
+++ b/lib/user-interface/app/src/translations/en.json
@@ -324,6 +324,7 @@
     "privacy.slide2.title": "We care about your privacy",
     "privacy.slide2.content": "We’re removing your personal information from the summaries. We will not store any of your or your child’s personal details.",
 
+    "carousel.section.hint": "Swipe or tap the arrows to learn more",
     "carousel.section.whatAiepDoes": "What AIEP does",
     "carousel.section.yourRights": "Your Rights",
     "carousel.section.whatYouWillSeeNext": "Where to find things",

--- a/lib/user-interface/app/src/translations/es.json
+++ b/lib/user-interface/app/src/translations/es.json
@@ -312,6 +312,7 @@
     "privacy.slide2.title": "Nos importa su privacidad",
     "privacy.slide2.content": "Estamos eliminando su información personal de los resúmenes. No almacenaremos ningún detalle personal suyo o de su hijo.",
 
+    "carousel.section.hint": "Deslice o toque las flechas para saber más",
     "carousel.section.whatAiepDoes": "Lo que hace AIEP",
     "carousel.section.yourRights": "Sus derechos",
     "carousel.section.whatYouWillSeeNext": "Dónde encontrar cada cosa",

--- a/lib/user-interface/app/src/translations/vi.json
+++ b/lib/user-interface/app/src/translations/vi.json
@@ -317,6 +317,7 @@
     "privacy.slide2.title": "Chúng tôi quan tâm đến quyền riêng tư của bạn",
     "privacy.slide2.content": "Chúng tôi đang loại bỏ thông tin cá nhân của bạn khỏi các bản tóm tắt. Chúng tôi sẽ không lưu trữ bất kỳ thông tin cá nhân nào của bạn hoặc con bạn.",
 
+    "carousel.section.hint": "Vuốt hoặc chạm vào mũi tên để tìm hiểu thêm",
     "carousel.section.whatAiepDoes": "AIEP làm gì",
     "carousel.section.yourRights": "Quyền của bạn",
     "carousel.section.whatYouWillSeeNext": "Tìm mọi thứ ở đâu",

--- a/lib/user-interface/app/src/translations/zh.json
+++ b/lib/user-interface/app/src/translations/zh.json
@@ -310,6 +310,7 @@
     "privacy.slide2.title": "我们关心您的隐私",
     "privacy.slide2.content": "我们正在从摘要中删除您的个人信息。我们不会存储您或您孩子的任何个人详细信息。",
 
+    "carousel.section.hint": "滑动或点按箭头，了解更多",
     "carousel.section.whatAiepDoes": "AIEP 的作用",
     "carousel.section.yourRights": "您的权利",
     "carousel.section.whatYouWillSeeNext": "在哪里找到各项内容",


### PR DESCRIPTION
Two commits that landed on `staging` after #58 was merged. Frontend copy only, plus one comment. No backend, infrastructure, or auth changes.

## What ships

**`b9d1666` — carousel dividers get body copy instead of an empty block.**

The height-parity fix in #58 forced a divider's text block to keep the full `228px` of every other slide, otherwise the indicator dots move under the parent's thumb while swiping. That left an obvious void under the divider title. It now carries a hint telling a parent how to move on.

The wording says **"the arrows"**, deliberately not "on the right". The app sets `document.documentElement.dir`, and this carousel's CSS rotates its own arrow glyphs under RTL so "next" points toward the end — meaning in Arabic the next control sits on the **left**. Naming a side would have sent Arabic readers backwards through the deck. A test asserts no locale's hint names a side, checking all five languages rather than just English.

The string arrives as a prop like the other translated copy, with an English default for the standalone `/rights-of-parents` route, which mounts the carousel with no translator.

**`0a0c39b` — a comment recording why the Vietnamese date keeps CLDR's comma form.**

`5 tháng 8, 2026` reads anglicized beside the other four locales, and written Vietnamese normally joins the year with `năm`. It is CLDR's own long-date pattern for `vi`, so it matches what every other app on a parent's phone shows, and that consistency was judged worth more than the more formal wording. Recorded so the next reader does not file it as a bug and special-case it. No behaviour change.

## Test plan

- [x] 112 frontend tests, 256 jest, full lint at `--max-warnings 0`, typechecks and build
- [x] Both new assertions mutation-checked: emptying the divider block again, and putting "on the right" back into the English string, each fail the test that names it

After deploy:

- [ ] The hint sits under each divider title without crowding it
- [ ] The indicator dots still hold steady across all three dividers
- [ ] Arabic: the hint reads correctly and the arrows still mirror

## Not addressed here

Both predate this work:

- The rights cards render cream headings on a light pink background, roughly **1.3:1 contrast**, effectively illegible. Affects all six rights slides.
- `AdminReferrals` still uses the icon web font, and two of its buttons are icon-only, so they are blank under iOS Lockdown Mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized guidance to carousel section dividers, telling users to swipe or tap the arrows for more information.
  * Improved support for Arabic and other RTL layouts with direction-neutral instructional text.
  * Enabled customizable carousel hints in processing screens.
* **Documentation**
  * Clarified Vietnamese date formatting behavior and localization guidance.
* **Tests**
  * Expanded carousel coverage across supported languages and layout directions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->